### PR TITLE
Set output file name, load birks' constant from GDML

### DIFF
--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -71,6 +71,7 @@ class RMGManager {
     inline void SetLogToFileName(std::string filename) { RMGLog::OpenLogFile(filename); }
 
     inline void SetOutputFileName(std::string filename) { fOutputFile = filename; }
+
   private:
 
     void SetUpDefaultG4RunManager();

--- a/include/RMGManager.hh
+++ b/include/RMGManager.hh
@@ -70,6 +70,7 @@ class RMGManager {
     void SetLogLevelFile(std::string level);
     inline void SetLogToFileName(std::string filename) { RMGLog::OpenLogFile(filename); }
 
+    inline void SetOutputFileName(std::string filename) { fOutputFile = filename; }
   private:
 
     void SetUpDefaultG4RunManager();

--- a/src/RMGHardware.cc
+++ b/src/RMGHardware.cc
@@ -125,7 +125,7 @@ void RMGHardware::ConstructSDandField() {
     G4double bc = mpt->GetConstProperty("BIRKSCONSTANT");
     mat->GetIonisation()->SetBirksConstant(bc);
     RMGLog::OutFormat(RMGLog::debug, "Birks constant of material {} set to {} mm/MeV from GDML",
-		mat->GetName(), bc / (CLHEP::mm / CLHEP::MeV));
+        mat->GetName(), bc / (CLHEP::mm / CLHEP::MeV));
   }
 }
 

--- a/src/RMGOpticalDetector.cc
+++ b/src/RMGOpticalDetector.cc
@@ -66,7 +66,7 @@ bool RMGOpticalDetector::ProcessHits(G4Step* step, G4TouchableHistory* /*history
   // hit when the photon reaches the boundary we need to check the
   // PostStepPoint here
   const auto pv_name = step->GetPostStepPoint()->GetPhysicalVolume()->GetName();
-  const auto pv_copynr = step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber();
+  const auto pv_copynr = step->GetPostStepPoint()->GetTouchableHandle()->GetCopyNumber();
 
   // check if physical volume is registered as optical detector
   auto det_cons = RMGManager::GetRMGManager()->GetDetectorConstruction();


### PR DESCRIPTION
This PR contains all my changes I did over the last weeks.

* Setting the output (root) file name
* Loading birks' constant from GDML as this might be handy
* One fix that just did not look right to me - but this should have not made any difference with a geometry loaded form GDML anyway (as the copy_nr is always 0)