### PR TITLE
Initialize particle source on master thread

### DIFF
--- a/src/RMGUserAction.cc
+++ b/src/RMGUserAction.cc
@@ -9,9 +9,12 @@
 #include "RMGTrackingAction.hh"
 
 void RMGUserAction::BuildForMaster() const {
-
-  // the master thread does not simulate anything
-  this->SetUserAction(new RMGRunAction(RMGManager::GetRMGManager()->IsPersistencyEnabled()));
+  // the master thread does not simulate anything.
+  // initialize the master generator also on the master thread, to make sure that particle source
+  // commands are available early on (following a note in G4GeneralParticleSourceMessenger.hh).
+  auto generator_primary = new RMGMasterGenerator();
+  this->SetUserAction(
+      new RMGRunAction(generator_primary, RMGManager::GetRMGManager()->IsPersistencyEnabled()));
 }
 
 void RMGUserAction::Build() const {


### PR DESCRIPTION
The note in https://github.com/Geant4/geant4/blob/99d10a46dc78367c58913995519648b8b2610d56/source/event/include/G4GeneralParticleSourceMessenger.hh#L221-L240 is right. Initializing the RMGMasterGenerator in BuildForMaster makes the MT mode work.

fixes #10 